### PR TITLE
Add the national instruments usb-6002 DAQ as a test rig.  This device…

### DIFF
--- a/rigs/dummy6002.jl
+++ b/rigs/dummy6002.jl
@@ -1,0 +1,52 @@
+#For testing using the National Instruments USB-6002 DAQ.
+rig_key = "dummy-6002"
+push!(RIGS, rig_key)
+#The device doesn't support buffered digital I/O so we use an analog output
+#for camera pulse commands and analog input to measure feedback
+
+const d6002_mappings = Dict("AO0"=>"axial piezo",
+                      "AO1"=>"camera1",
+                      "AI0"=>"axial piezo monitor",
+                      "AI1"=>"camera1 frame monitor",
+                      "AI2"=>"analogin1",
+                      "AI3"=>"analogin2",
+                      "AI4"=>"analogin3",
+                      "AI5"=>"analogin4",
+                      "AI6"=>"analogin5",
+                      "AI7"=>"analogin6")
+
+DEFAULT_DAQCHANS_TO_NAMES[rig_key] = d6002_mappings
+DEFAULT_NAMES_TO_DAQCHANS[rig_key] = map(reverse, d6002_mappings)
+
+const d6002_aochans = map(x->"AO$(x)", 0:1)
+const d6002_aichans = map(x->"AI$(x)", [0:7...])
+const d6002_dochans = String[]
+const d6002_dichans = String[]
+const d6002_pos_ctrl_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["axial piezo"])
+const d6002_pos_mon_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["axial piezo monitor"])
+const d6002_cam_ctrl_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["camera1"])
+const d6002_cam_mon_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["camera1 frame monitor"])
+const d6002_laschans = String[]
+const d6002_stimchans = String[]
+const d6002_fixed_names = ["axial piezo", "axial piezo monitor", "camera1", "camera1 frame monitor"]
+const d6002_fixed_daqchans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], d6002_fixed_names)
+
+AO_CHANS[rig_key] = OrderedSet(d6002_aochans)
+AI_CHANS[rig_key] = OrderedSet(d6002_aichans)
+DO_CHANS[rig_key] = OrderedSet(d6002_dochans)
+DI_CHANS[rig_key] = OrderedSet(d6002_dichans)
+POS_CONTROL_CHANS[rig_key] = d6002_pos_ctrl_chans
+POS_MONITOR_CHANS[rig_key] = d6002_pos_mon_chans
+CAM_CONTROL_CHANS[rig_key] = d6002_cam_ctrl_chans
+CAM_MONITOR_CHANS[rig_key] = d6002_cam_mon_chans
+LAS_CONTROL_CHANS[rig_key] = d6002_laschans
+STIM_CHANS[rig_key] =OrderedSet(d6002_stimchans)
+FIXED_NAMES[rig_key] = d6002_fixed_names
+FIXED_DAQ_CHANS[rig_key] = d6002_fixed_daqchans
+
+RIG_CHIP_SIZES[rig_key] = PCO_EDGE_4_2_CHIP_SIZE
+RIG_FRAMERATE_FUNCS[rig_key] = PCO_EDGE_4_2_FRAMERATE_FUNC
+
+PIEZO_RANGES[rig_key] = (0.0μm .. 400.0μm, 0.0V .. 10.0V)
+AO_RANGE[rig_key] = -10.0V .. 10.0V
+AI_RANGE[rig_key] = AO_RANGE[rig_key] #TODO: make sure this is true.  (true if we are recording -10..10V on analog inputs)

--- a/rigs/ocpi1.jl
+++ b/rigs/ocpi1.jl
@@ -1,4 +1,5 @@
-push!(RIGS, "ocpi-1")
+rig_key = "ocpi-1"
+push!(RIGS, rig_key)
 #Mappings from DAQ channel to friendlier default names
 const ocpi1_mappings = Dict("AO0"=>"axial piezo",
                       "AO1"=>"analogout1",
@@ -26,34 +27,39 @@ const ocpi1_mappings = Dict("AO0"=>"axial piezo",
                       "P0.6"=>"stimulus5",
                       "P0.7"=>"camera1 frame monitor")
 
-DEFAULT_DAQCHANS_TO_NAMES["ocpi-1"] = ocpi1_mappings
-DEFAULT_NAMES_TO_DAQCHANS["ocpi-1"] = map(reverse, ocpi1_mappings)
+DEFAULT_DAQCHANS_TO_NAMES[rig_key] = ocpi1_mappings
+DEFAULT_NAMES_TO_DAQCHANS[rig_key] = map(reverse, ocpi1_mappings)
 
 const ocpi1_aochans = map(x->"AO$(x)", 0:1)
 const ocpi1_aichans = map(x->"AI$(x)", vcat([0;], [2:15...])) #currently AI1 is unused 
 const ocpi1_dochans = map(x->"P0.$(x)", 0:6)
 const ocpi1_dichans = ["P0.7";]
-const ocpi1_pos_ctrl_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS["ocpi-1"][x], ["axial piezo"])
-const ocpi1_pos_mon_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS["ocpi-1"][x], ["axial piezo monitor"])
-const ocpi1_cam_ctrl_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS["ocpi-1"][x], ["camera1"])
-const ocpi1_cam_mon_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS["ocpi-1"][x], ["camera1 frame monitor"])
-const ocpi1_laschans = map(x->DEFAULT_NAMES_TO_DAQCHANS["ocpi-1"][x], ["488nm laser shutter"])
-const ocpi1_stimchans = map(x->DEFAULT_NAMES_TO_DAQCHANS["ocpi-1"][x], ["stimulus$x" for x = 1:5])
+const ocpi1_pos_ctrl_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["axial piezo"])
+const ocpi1_pos_mon_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["axial piezo monitor"])
+const ocpi1_cam_ctrl_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["camera1"])
+const ocpi1_cam_mon_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["camera1 frame monitor"])
+const ocpi1_laschans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["488nm laser shutter"])
+const ocpi1_stimchans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["stimulus$x" for x = 1:5])
 const ocpi1_fixed_names = ["axial piezo", "axial piezo monitor", "488nm laser shutter", "camera1", "camera1 frame monitor"]
-const ocpi1_fixed_daqchans = map(x->DEFAULT_NAMES_TO_DAQCHANS["ocpi-1"][x], ocpi1_fixed_names)
+const ocpi1_fixed_daqchans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ocpi1_fixed_names)
 
-AO_CHANS["ocpi-1"] = OrderedSet(ocpi1_aochans)
-AI_CHANS["ocpi-1"] = OrderedSet(ocpi1_aichans)
-DO_CHANS["ocpi-1"] = OrderedSet(ocpi1_dochans)
-DI_CHANS["ocpi-1"] = OrderedSet(ocpi1_dichans)
-POS_CONTROL_CHANS["ocpi-1"] = ocpi1_pos_ctrl_chans
-POS_MONITOR_CHANS["ocpi-1"] = ocpi1_pos_mon_chans
-CAM_CONTROL_CHANS["ocpi-1"] = ocpi1_cam_ctrl_chans
-CAM_MONITOR_CHANS["ocpi-1"] = ocpi1_cam_mon_chans
-LAS_CONTROL_CHANS["ocpi-1"] = ocpi1_laschans
-STIM_CHANS["ocpi-1"] =OrderedSet(ocpi1_stimchans)
-FIXED_NAMES["ocpi-1"] = ocpi1_fixed_names
-FIXED_DAQ_CHANS["ocpi-1"] = ocpi1_fixed_daqchans
+AO_CHANS[rig_key] = OrderedSet(ocpi1_aochans)
+AI_CHANS[rig_key] = OrderedSet(ocpi1_aichans)
+DO_CHANS[rig_key] = OrderedSet(ocpi1_dochans)
+DI_CHANS[rig_key] = OrderedSet(ocpi1_dichans)
+POS_CONTROL_CHANS[rig_key] = ocpi1_pos_ctrl_chans
+POS_MONITOR_CHANS[rig_key] = ocpi1_pos_mon_chans
+CAM_CONTROL_CHANS[rig_key] = ocpi1_cam_ctrl_chans
+CAM_MONITOR_CHANS[rig_key] = ocpi1_cam_mon_chans
+LAS_CONTROL_CHANS[rig_key] = ocpi1_laschans
+STIM_CHANS[rig_key] =OrderedSet(ocpi1_stimchans)
+FIXED_NAMES[rig_key] = ocpi1_fixed_names
+FIXED_DAQ_CHANS[rig_key] = ocpi1_fixed_daqchans
 
-RIG_CHIP_SIZES["ocpi-1"] = PCO_EDGE_5_5_CHIP_SIZE
-RIG_FRAMERATE_FUNCS["ocpi-1"] = PCO_EDGE_5_5_FRAMERATE_FUNC
+RIG_CHIP_SIZES[rig_key] = PCO_EDGE_5_5_CHIP_SIZE
+RIG_FRAMERATE_FUNCS[rig_key] = PCO_EDGE_5_5_FRAMERATE_FUNC
+
+PIEZO_RANGES[rig_key] = (0.0μm .. 400.0μm, 0.0V .. 10.0V)
+AO_RANGE[rig_key] = -10.0V .. 10.0V
+AI_RANGE[rig_key] = AO_RANGE[rig_key] #TODO: make sure this is true.  (true if we are recording -10..10V on analog inputs)
+

--- a/rigs/ocpi2.jl
+++ b/rigs/ocpi2.jl
@@ -1,4 +1,5 @@
-push!(RIGS, "ocpi-2")
+rig_key = "ocpi-2"
+push!(RIGS, rig_key)
 
 const ocpi2_mappings = Dict("AO0"=>"axial piezo",
                       "AO1"=>"horizontal piezo",
@@ -69,34 +70,38 @@ const ocpi2_mappings = Dict("AO0"=>"axial piezo",
                       "P0.30"=>"diginput5",
                       "P0.31"=>"diginput6",)
 
-DEFAULT_DAQCHANS_TO_NAMES["ocpi-2"] = ocpi2_mappings
-DEFAULT_NAMES_TO_DAQCHANS["ocpi-2"] = map(reverse, ocpi2_mappings)
+DEFAULT_DAQCHANS_TO_NAMES[rig_key] = ocpi2_mappings
+DEFAULT_NAMES_TO_DAQCHANS[rig_key] = map(reverse, ocpi2_mappings)
 
 const ocpi2_aochans = map(x->"AO$(x)", 0:3) 
 const ocpi2_aichans = map(x->"AI$(x)", 0:31)
 const ocpi2_dochans = map(x->"P0.$(x)", vcat([0:6...], [8:23...])) 
 const ocpi2_dichans = map(x->"P0.$(x)", 24:31)
-const ocpi2_pos_ctrl_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS["ocpi-2"][x], ["axial piezo"; "horizontal piezo"])
-const ocpi2_pos_mon_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS["ocpi-2"][x], ["axial piezo monitor"; "horizontal piezo monitor"])
-const ocpi2_cam_ctrl_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS["ocpi-2"][x], ["camera1"; "camera2"])
-const ocpi2_cam_mon_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS["ocpi-2"][x], ["camera1 frame monitor"; "camera2 frame monitor"])
-const ocpi2_laschans = map(x->DEFAULT_NAMES_TO_DAQCHANS["ocpi-2"][x], ["405nm laser"; "445nm laser"; "488nm laser"; "514nm laser"; "561nm laser"; "all lasers"])
-const ocpi2_stimchans = map(x->DEFAULT_NAMES_TO_DAQCHANS["ocpi-2"][x], ["stimulus$x" for x = 1:15])
+const ocpi2_pos_ctrl_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["axial piezo"; "horizontal piezo"])
+const ocpi2_pos_mon_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["axial piezo monitor"; "horizontal piezo monitor"])
+const ocpi2_cam_ctrl_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["camera1"; "camera2"])
+const ocpi2_cam_mon_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["camera1 frame monitor"; "camera2 frame monitor"])
+const ocpi2_laschans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["405nm laser"; "445nm laser"; "488nm laser"; "514nm laser"; "561nm laser"; "all lasers"])
+const ocpi2_stimchans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["stimulus$x" for x = 1:15])
 const ocpi2_fixed_names = ["axial piezo", "axial piezo monitor", "horizontal piezo", "horizontal piezo monitor", "camera1", "camera1 frame monitor", "camera2", "camera2 frame monitor", "405nm laser", "445nm laser", "488nm laser", "514nm laser", "561nm laser"]
-const ocpi2_fixed_daqchans = map(x->DEFAULT_NAMES_TO_DAQCHANS["ocpi-2"][x], ocpi2_fixed_names)
+const ocpi2_fixed_daqchans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ocpi2_fixed_names)
 
-AO_CHANS["ocpi-2"] = OrderedSet(ocpi2_aochans)
-AI_CHANS["ocpi-2"] = OrderedSet(ocpi2_aichans)
-DO_CHANS["ocpi-2"] = OrderedSet(ocpi2_dochans)
-DI_CHANS["ocpi-2"] = OrderedSet(ocpi2_dichans)
-POS_CONTROL_CHANS["ocpi-2"] = ocpi2_pos_ctrl_chans
-POS_MONITOR_CHANS["ocpi-2"] = ocpi2_pos_mon_chans
-CAM_CONTROL_CHANS["ocpi-2"] = ocpi2_cam_ctrl_chans
-CAM_MONITOR_CHANS["ocpi-2"] = ocpi2_cam_mon_chans
-LAS_CONTROL_CHANS["ocpi-2"] = ocpi2_laschans
-STIM_CHANS["ocpi-2"] =OrderedSet(ocpi2_stimchans)
-FIXED_NAMES["ocpi-2"] = ocpi2_fixed_names
-FIXED_DAQ_CHANS["ocpi-2"] = ocpi2_fixed_daqchans
+AO_CHANS[rig_key] = OrderedSet(ocpi2_aochans)
+AI_CHANS[rig_key] = OrderedSet(ocpi2_aichans)
+DO_CHANS[rig_key] = OrderedSet(ocpi2_dochans)
+DI_CHANS[rig_key] = OrderedSet(ocpi2_dichans)
+POS_CONTROL_CHANS[rig_key] = ocpi2_pos_ctrl_chans
+POS_MONITOR_CHANS[rig_key] = ocpi2_pos_mon_chans
+CAM_CONTROL_CHANS[rig_key] = ocpi2_cam_ctrl_chans
+CAM_MONITOR_CHANS[rig_key] = ocpi2_cam_mon_chans
+LAS_CONTROL_CHANS[rig_key] = ocpi2_laschans
+STIM_CHANS[rig_key] =OrderedSet(ocpi2_stimchans)
+FIXED_NAMES[rig_key] = ocpi2_fixed_names
+FIXED_DAQ_CHANS[rig_key] = ocpi2_fixed_daqchans
 
-RIG_CHIP_SIZES["ocpi-2"] = PCO_EDGE_4_2_CHIP_SIZE
-RIG_FRAMERATE_FUNCS["ocpi-2"] = PCO_EDGE_4_2_FRAMERATE_FUNC
+RIG_CHIP_SIZES[rig_key] = PCO_EDGE_4_2_CHIP_SIZE
+RIG_FRAMERATE_FUNCS[rig_key] = PCO_EDGE_4_2_FRAMERATE_FUNC
+
+PIEZO_RANGES[rig_key] = (0.0μm .. 800.0μm, 0.0V .. 10.0V)
+AO_RANGE[rig_key] = -10.0V .. 10.0V
+AI_RANGE[rig_key] = AO_RANGE[rig_key] #TODO: make sure this is true.  (true if we are recording -10..10V on analog inputs)

--- a/rigs/ocpi_lsk.jl
+++ b/rigs/ocpi_lsk.jl
@@ -1,4 +1,5 @@
-push!(RIGS, "ocpi-lsk")
+rig_key = "ocpi-lsk"
+push!(RIGS, rig_key)
 
 #Much like OCPI2, but with missing channels for missing hardware
 const ocpi_lsk_mappings = Dict("AO0"=>"axial piezo",
@@ -70,35 +71,39 @@ const ocpi_lsk_mappings = Dict("AO0"=>"axial piezo",
                       "P0.30"=>"diginput5",
                       "P0.31"=>"diginput6",)
 
-DEFAULT_DAQCHANS_TO_NAMES["ocpi-lsk"] = ocpi_lsk_mappings
-DEFAULT_NAMES_TO_DAQCHANS["ocpi-lsk"] = map(reverse, ocpi_lsk_mappings)
+DEFAULT_DAQCHANS_TO_NAMES[rig_key] = ocpi_lsk_mappings
+DEFAULT_NAMES_TO_DAQCHANS[rig_key] = map(reverse, ocpi_lsk_mappings)
 
-const ocpi_lsk_pos_ctrl_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS["ocpi-lsk"][x], ["axial piezo"])
+const ocpi_lsk_pos_ctrl_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["axial piezo"])
 const ocpi_lsk_aochans = map(x->"AO$(x)", [0;2;3]) 
 const ocpi_lsk_aichans = map(x->"AI$(x)", vcat([0;], [2:15...])) #currently AI1 is unused 
 const ocpi_lsk_dochans = map(x->"P0.$(x)", vcat([0:5...], [13:23...])) 
 const ocpi_lsk_dichans = map(x->"P0.$(x)", vcat([24;], [26:31...]))
-const ocpi_lsk_pos_mon_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS["ocpi-lsk"][x], ["axial piezo monitor"])
-const ocpi_lsk_cam_ctrl_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS["ocpi-lsk"][x], ["camera1"])
-const ocpi_lsk_cam_mon_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS["ocpi-lsk"][x], ["camera1 frame monitor"])
-const ocpi_lsk_laschans = map(x->DEFAULT_NAMES_TO_DAQCHANS["ocpi-lsk"][x], ["all lasers"])
-const ocpi_lsk_stimchans = map(x->DEFAULT_NAMES_TO_DAQCHANS["ocpi-lsk"][x], ["stimulus$x" for x = 1:15])
+const ocpi_lsk_pos_mon_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["axial piezo monitor"])
+const ocpi_lsk_cam_ctrl_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["camera1"])
+const ocpi_lsk_cam_mon_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["camera1 frame monitor"])
+const ocpi_lsk_laschans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["all lasers"])
+const ocpi_lsk_stimchans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["stimulus$x" for x = 1:15])
 const ocpi_lsk_fixed_names = ["axial piezo", "axial piezo monitor", "all lasers", "camera1", "camera1 frame monitor"]
-const ocpi_lsk_fixed_daqchans = map(x->DEFAULT_NAMES_TO_DAQCHANS["ocpi-lsk"][x], ocpi_lsk_fixed_names)
+const ocpi_lsk_fixed_daqchans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ocpi_lsk_fixed_names)
 
-AO_CHANS["ocpi-lsk"] = OrderedSet(ocpi_lsk_aochans)
-AI_CHANS["ocpi-lsk"] = OrderedSet(ocpi_lsk_aichans)
-DO_CHANS["ocpi-lsk"] = OrderedSet(ocpi_lsk_dochans)
-DI_CHANS["ocpi-lsk"] = OrderedSet(ocpi_lsk_dichans)
-POS_CONTROL_CHANS["ocpi-lsk"] = ocpi_lsk_pos_ctrl_chans
-POS_MONITOR_CHANS["ocpi-lsk"] = ocpi_lsk_pos_mon_chans
-CAM_CONTROL_CHANS["ocpi-lsk"] = ocpi_lsk_cam_ctrl_chans
-CAM_MONITOR_CHANS["ocpi-lsk"] = ocpi_lsk_cam_mon_chans
-LAS_CONTROL_CHANS["ocpi-lsk"] = ocpi_lsk_laschans
-STIM_CHANS["ocpi-lsk"] =OrderedSet(ocpi_lsk_stimchans)
-FIXED_NAMES["ocpi-lsk"] = ocpi_lsk_fixed_names
-FIXED_DAQ_CHANS["ocpi-lsk"] = ocpi_lsk_fixed_daqchans
+AO_CHANS[rig_key] = OrderedSet(ocpi_lsk_aochans)
+AI_CHANS[rig_key] = OrderedSet(ocpi_lsk_aichans)
+DO_CHANS[rig_key] = OrderedSet(ocpi_lsk_dochans)
+DI_CHANS[rig_key] = OrderedSet(ocpi_lsk_dichans)
+POS_CONTROL_CHANS[rig_key] = ocpi_lsk_pos_ctrl_chans
+POS_MONITOR_CHANS[rig_key] = ocpi_lsk_pos_mon_chans
+CAM_CONTROL_CHANS[rig_key] = ocpi_lsk_cam_ctrl_chans
+CAM_MONITOR_CHANS[rig_key] = ocpi_lsk_cam_mon_chans
+LAS_CONTROL_CHANS[rig_key] = ocpi_lsk_laschans
+STIM_CHANS[rig_key] =OrderedSet(ocpi_lsk_stimchans)
+FIXED_NAMES[rig_key] = ocpi_lsk_fixed_names
+FIXED_DAQ_CHANS[rig_key] = ocpi_lsk_fixed_daqchans
 
 #TODO: check these
-#RIG_CHIP_SIZES["ocpi-lsk"] = PCO_EDGE_5_5_CHIP_SIZE
-#RIG_FRAMERATE_FUNCS["ocpi-lsk"] = PCO_EDGE_5_5_FRAMERATE_FUNC
+#RIG_CHIP_SIZES[rig_key] = PCO_EDGE_5_5_CHIP_SIZE
+#RIG_FRAMERATE_FUNCS[rig_key] = PCO_EDGE_5_5_FRAMERATE_FUNC
+
+PIEZO_RANGES[rig_key] = (0.0μm .. 400.0μm, 0.0V .. 10.0V)
+AO_RANGE[rig_key] = -10.0V .. 10.0V
+AI_RANGE[rig_key] = AO_RANGE[rig_key] #TODO: make sure this is true.  (true if we are recording -10..10V on analog inputs)

--- a/src/metadata_constants.jl
+++ b/src/metadata_constants.jl
@@ -42,6 +42,11 @@ const FIXED_DAQ_CHANS = Dict()
 const RIG_CHIP_SIZES = Dict()
 #functions for calculating frame rate given two arguments: horizontal ROI size and vertical ROI size (in pixels)
 const RIG_FRAMERATE_FUNCS = Dict()
+#voltage ranges of analog channels
+const AO_RANGE = Dict()
+const AI_RANGE = Dict()
+#Tuple of intervals describing the distance range and voltage range of the piezo for each rig
+const PIEZO_RANGES = Dict()
 
 #Utility functions for querying rig channel information
 daq_channel_number(ch::String) = parse(Int, last(split("AO0", ['.', 'I', 'O'])))

--- a/src/samplemapper.jl
+++ b/src/samplemapper.jl
@@ -12,6 +12,8 @@ end
 
 raw2volts{Traw,TW}(mapper::SampleMapper{Traw,TW}) = x::Traw -> mapper.voltmin + ((Int(x)-mapper.rawmin)/(Int(mapper.rawmax)-mapper.rawmin))*(mapper.voltmax-mapper.voltmin)
 volts2world{Traw,TW}(mapper::SampleMapper{Traw,TW}) = x::HasVoltageUnits -> convert(TW, mapper.worldmin + ((x-mapper.voltmin)/(mapper.voltmax-mapper.voltmin))*(mapper.worldmax-mapper.worldmin))
+#A specialized version for mapping digital voltages encoded in analog channels
+volts2world{Traw<:Integer,TW<:Bool}(mapper::SampleMapper{Traw,TW}) = x::HasVoltageUnits -> convert(TW, (x-mapper.voltmin)/(mapper.voltmax-mapper.voltmin)>0.5 ? true : false)
 world2volts{Traw,TW}(mapper::SampleMapper{Traw,TW}) = x::TW -> mapper.voltmin + ((x-mapper.worldmin)/(mapper.worldmax-mapper.worldmin))*(mapper.voltmax-mapper.voltmin)
 
 function volts2raw{Traw,TW}(mapper::SampleMapper{Traw,TW})


### PR DESCRIPTION
… doesn't support buffered digital I/O, so camera I/O is routed with analog ImagineSignals.  Minor changes were required to make that work.  Also some cleanup of the rig config files.