### PR TITLE
Allow append! to accept sample vectors that are already compressed (a…

### DIFF
--- a/src/ImagineInterface.jl
+++ b/src/ImagineInterface.jl
@@ -42,7 +42,10 @@ export chip_size,
         isstim
 
 #imaginecommand.jl
-export ImagineSignal,
+export RepeatedValue,
+        RLEVector,
+        full_length,
+        ImagineSignal,
         name,
         rename!,
         duration,

--- a/test/low_level.jl
+++ b/test/low_level.jl
@@ -126,6 +126,16 @@ dat = get_samples(pos, "ramp_up")
 append!(pos, "ramp_up") #append existing
 @test length(pos) == 2*typemax(Int16)+2
 
+#append! already compressed
+stim1 = getstimuli(ocpi2)[1]
+stim2 = getstimuli(ocpi2)[2]
+append!(stim1, "on_100", trues(100))
+rlev = RepeatedValue{rawtype(stim2)}[]
+push!(rlev, RepeatedValue(100, true))
+append!(stim2, "on_100_2", rlev)
+@test length(stim1) == length(stim2)
+@test all(get_samples(stim1) .== get_samples(stim2))
+
 #test invalid sample types
 rawdat = Int32[1:5...]
 @test_throws(Exception, append!(pos, "bad", rawdat))


### PR DESCRIPTION
…s RLEVectors).  Also export RepeatedValue, RLEVector, and full_length function for getting total sample count of an RLEVector.

This allows digital signals to be generated much more quickly since it's not required to iterate through them when they are appended to an ImagineSignal